### PR TITLE
feat: 文本消息发送功能

### DIFF
--- a/apps/server/src/services/juhexbotAdapter.ts
+++ b/apps/server/src/services/juhexbotAdapter.ts
@@ -114,12 +114,14 @@ export class JuhexbotAdapter {
   async sendRequest<T>(path: string, data: T): Promise<{ errcode: number; errmsg: string; data: any }> {
     const fullPath = path.startsWith('/') ? path : `/${path}`
     const request = this.buildGatewayRequest(fullPath, data)
+    logger.info({ path: fullPath, apiUrl: this.config.apiUrl, requestBody: request }, 'juhexbot API request')
     const response = await fetch(this.config.apiUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(request)
     })
     const result = await response.json() as any
+    logger.info({ path: fullPath, httpStatus: response.status, rawResponse: result }, 'juhexbot API response')
     // juhexbot API 返回字段不统一，统一为 errcode/errmsg
     // 有些接口用 errcode/err_code，有些用 baseResponse.ret
     const errcode = result.errcode ?? result.err_code ?? result.baseResponse?.ret ?? -1
@@ -148,7 +150,7 @@ export class JuhexbotAdapter {
   }
 
   async sendTextMessage(toUsername: string, content: string): Promise<{ msgId: string }> {
-    const result = await this.sendRequest('/message/send_text', {
+    const result = await this.sendRequest('/msg/send_text', {
       guid: this.config.clientGuid,
       to_username: toUsername,
       content


### PR DESCRIPTION
## 概述

完善文本消息发送功能，实现乐观更新和前后端去重。

## 改动

### 后端
- `sendMessage` 返回完整消息对象
- 路由返回格式包装为 `{ message: ... }`
- `handleIncomingMessage` 实现 msgId 去重
- 新增 `findMessageIndexByMsgId` 数据库方法
- 修复发送文本消息 API 路径：`/message/send_text` → `/msg/send_text`

### 前端
- `useSendMessage` 乐观更新（onMutate/onSuccess/onError）
- `pendingMessages` 模块管理待确认消息 ID
- `appendMessage` 去重逻辑
- 类型检查错误修复